### PR TITLE
Use SQLite to persist audio metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,18 @@
 version = 3
 
 [[package]]
+name = "ahash"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -108,8 +120,7 @@ dependencies = [
  "rand",
  "rodio",
  "rubato",
- "serde",
- "serde_json",
+ "rusqlite",
  "threadpool",
  "walkdir",
 ]
@@ -472,6 +483,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fastrand"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -508,6 +531,18 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown",
+]
 
 [[package]]
 name = "heed"
@@ -696,6 +731,17 @@ checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
  "bitflags 2.5.0",
  "libc",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c10584274047cb335c23d3e61bcef8e323adae7c5c8c760540f73610177fc3f"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -1170,6 +1216,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusqlite"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b838eba278d213a8beaf485bd313fd580ca4505a00d5871caeb1457c55322cae"
+dependencies = [
+ "bitflags 2.5.0",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1260,6 +1320,12 @@ name = "siphasher"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
+
+[[package]]
+name = "smallvec"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "strength_reduce"
@@ -1480,6 +1546,12 @@ dependencies = [
  "idna",
  "percent-encoding",
 ]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vec_map"
@@ -1866,4 +1938,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,6 +121,7 @@ dependencies = [
  "rodio",
  "rubato",
  "rusqlite",
+ "serde",
  "threadpool",
  "walkdir",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,5 +16,4 @@ arroy = "0.3.1"
 heed = "0.20.2"
 rand = "0.8.5"
 directories = "5.0.1"
-serde = "1.0.203"
-serde_json = "1.0.118"
+rusqlite = { version = "0.31.0", features = ["bundled"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,4 @@ heed = "0.20.2"
 rand = "0.8.5"
 directories = "5.0.1"
 rusqlite = { version = "0.31.0", features = ["bundled"] }
+serde = "1.0.203"

--- a/src/file_utils.rs
+++ b/src/file_utils.rs
@@ -17,11 +17,11 @@ pub fn data_directory() -> Result<PathBuf, String> {
     Ok(data_local_dir.to_path_buf())
 }
 
-pub fn feature_file_path() -> Result<PathBuf, String> {
-    Ok(data_directory()?.join("features"))
+pub fn metadata_db_path() -> Result<PathBuf, String> {
+    Ok(data_directory()?.join("md.db"))
 }
 
-pub fn db_path() -> Result<PathBuf, String> {
+pub fn vector_db_path() -> Result<PathBuf, String> {
     Ok(data_directory()?.join("data.mdb"))
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,8 +26,8 @@ pub fn build_db(asset_dir: &str) -> Result<VectorDatabase, String> {
     Ok(db)
 }
 
-// pub fn find_similar(source_id: u32, num_results: usize) -> Result<Vec<u32>, String> {
-//     // Otherwise, load the existing db from disk and query it
-//     let db = VectorDatabase::load_from_disk()?;
-//     db.find_similar(source_id, num_results)
-// }
+pub fn find_similar(source_id: u32, num_results: usize) -> Result<Vec<u32>, String> {
+    // Otherwise, load the existing db from disk and query it
+    let db = VectorDatabase::load_from_disk()?;
+    db.find_similar(source_id, num_results)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 
 use std::time::Instant;
 
+use metadata_db::{AudioFile, MetadataDatabase};
 use vector_db::VectorDatabase;
 
 pub mod feature_extractor;
@@ -30,4 +31,9 @@ pub fn find_similar(source_id: u32, num_results: usize) -> Result<Vec<u32>, Stri
     // Otherwise, load the existing db from disk and query it
     let db = VectorDatabase::load_from_disk()?;
     db.find_similar(source_id, num_results)
+}
+
+pub fn list_audio_files(start_offset: u32, num_results: u32) -> Result<Vec<AudioFile>, String> {
+    let db = MetadataDatabase::load_from_disk()?;
+    db.list_audio_files(start_offset, num_results)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,10 +27,12 @@ pub fn build_db(asset_dir: &str) -> Result<VectorDatabase, String> {
     Ok(db)
 }
 
-pub fn find_similar(source_id: u32, num_results: usize) -> Result<Vec<u32>, String> {
+pub fn find_similar(source_id: u32, num_results: usize) -> Result<Vec<AudioFile>, String> {
     // Otherwise, load the existing db from disk and query it
-    let db = VectorDatabase::load_from_disk()?;
-    db.find_similar(source_id, num_results)
+    let vec_db = VectorDatabase::load_from_disk()?;
+    let ids = vec_db.find_similar(source_id, num_results)?;
+    let md_db = MetadataDatabase::load_from_disk()?;
+    md_db.get_audio_files_for_ids(&ids)
 }
 
 pub fn list_audio_files(start_offset: u32, num_results: u32) -> Result<Vec<AudioFile>, String> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,11 +3,11 @@
 
 use std::time::Instant;
 
-pub use feature_extractor::FeatureMetadata;
 use vector_db::VectorDatabase;
 
 pub mod feature_extractor;
 mod file_utils;
+pub mod metadata_db;
 pub mod vector_db;
 
 pub fn build_db(asset_dir: &str) -> Result<VectorDatabase, String> {
@@ -15,51 +15,19 @@ pub fn build_db(asset_dir: &str) -> Result<VectorDatabase, String> {
     let features =
         feature_extractor::extract_features(feature_extractor::RunMode::Parallel, asset_dir)
             .unwrap();
-    feature_extractor::save_to_file(&features, asset_dir.to_string())?;
     let elapsed = start_time.elapsed();
     println!("Took {:.1?} to extract features", elapsed);
 
     let start_time = Instant::now();
-    let db =
-        VectorDatabase::from_features(&features, feature_extractor::NUM_DIMENSIONS, asset_dir)?;
+    let db = VectorDatabase::build(&features, asset_dir, feature_extractor::NUM_DIMENSIONS)?;
     let elapsed = start_time.elapsed();
     println!("Took {:.1?} to build database", elapsed);
 
     Ok(db)
 }
 
-/// A valid asset_dir can be provided to verify that entries for the requested
-/// asset directory were found in the db. If not, an error will be returned.
-pub fn load_db_from_disk(asset_dir: Option<&str>) -> Result<VectorDatabase, String> {
-    VectorDatabase::load_from_disk(asset_dir)
-}
-
-pub fn load_feature_metadata_from_disk() -> Result<FeatureMetadata, String> {
-    feature_extractor::from_file(None)
-}
-
-/// A valid asset_dir can be provided to verify that audio files for the requested
-/// asset directory were found. If not, an error will be returned.
-pub fn list_audio_files(asset_dir: Option<&str>) -> Result<Vec<String>, String> {
-    // TODO: right now this lists 100 arbitrary files. Ideally the files
-    // would be returned in order, and the client could request an arbitrary
-    // subset of files.
-    Ok(feature_extractor::from_file(asset_dir)?
-        .feature_map()
-        .values()
-        .take(100)
-        .map(|v| v.to_string())
-        .collect())
-}
-
-/// A valid asset_dir can be provided to verify that entries for the requested
-/// asset directory were found. If not, an error will be returned.
-pub fn find_similar(
-    source_id: u32,
-    num_results: usize,
-    asset_dir: Option<&str>,
-) -> Result<Vec<String>, String> {
-    // Otherwise, load the existing db from disk and query it
-    let db = VectorDatabase::load_from_disk(asset_dir)?;
-    db.find_similar(source_id, num_results)
-}
+// pub fn find_similar(source_id: u32, num_results: usize) -> Result<Vec<u32>, String> {
+//     // Otherwise, load the existing db from disk and query it
+//     let db = VectorDatabase::load_from_disk()?;
+//     db.find_similar(source_id, num_results)
+// }

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,8 +55,8 @@ fn main() {
 
 fn list_samples() {
     let db = MetadataDatabase::load_from_disk().unwrap();
-    let paths = db.list_file_paths().unwrap();
-    for path in paths.iter() {
-        println!("{}", path);
+    let files = db.list_audio_files(0, 1000).unwrap();
+    for file in files.iter() {
+        println!("{}", file.path());
     }
 }

--- a/src/metadata_db.rs
+++ b/src/metadata_db.rs
@@ -1,11 +1,12 @@
-use rusqlite::{Connection, Result};
-
 use crate::file_utils;
+use rusqlite::{Connection, Result};
+use serde::{Deserialize, Serialize};
 
 pub struct MetadataDatabase {
     connection: Connection,
 }
 
+#[derive(Serialize, Deserialize)]
 pub struct AudioFile {
     id: i64,
     path: String,

--- a/src/metadata_db.rs
+++ b/src/metadata_db.rs
@@ -1,0 +1,111 @@
+use rusqlite::{Connection, Result};
+
+use crate::file_utils;
+
+pub struct MetadataDatabase {
+    connection: Connection,
+}
+
+impl MetadataDatabase {
+    pub fn load_from_disk() -> Result<MetadataDatabase, String> {
+        let file_path = file_utils::metadata_db_path()?;
+        let connection = Connection::open(&file_path)
+            .map_err(|e| format!("Failed to create database: {}", e))?;
+
+        Ok(MetadataDatabase { connection })
+    }
+
+    /// Creates necessary db tables and inserts an entry for analysis_root_dir.
+    /// Returns the analysis root dir ID on success.
+    pub fn initialize(&self, analysis_root_dir: &str) -> Result<i64, String> {
+        self.connection
+            .execute(
+                "CREATE TABLE IF NOT EXISTS analysis_root_dirs (
+                    id INTEGER PRIMARY KEY,
+                    dir_path TEXT NOT NULL
+                )",
+                (),
+            )
+            .map_err(|e| e.to_string())?;
+
+        self.connection
+            .execute(
+                "CREATE TABLE IF NOT EXISTS samples (
+                    id INTEGER PRIMARY KEY,
+                    analysis_root_dir_id INTEGER,
+                    file_path TEXT NOT NULL,
+                    FOREIGN KEY(analysis_root_dir_id) REFERENCES analysis_root_dirs(id)
+                )",
+                (),
+            )
+            .map_err(|e| format!("Failed to create db table: {}", e))?;
+
+        self.connection
+            .execute(
+                "CREATE INDEX IF NOT EXISTS idx_file_path ON samples (file_path)",
+                (),
+            )
+            .map_err(|e| format!("Failed to create db index: {}", e))?;
+
+        let id = self.get_id_for_analysis_dir(analysis_root_dir)?;
+        Ok(id)
+    }
+
+    fn get_id_for_analysis_dir(&self, analysis_root_dir: &str) -> Result<i64, String> {
+        let root_dir_query = "SELECT id from analysis_root_dirs WHERE dir_path=?1";
+        let mut root_dir_stmt = self
+            .connection
+            .prepare(root_dir_query)
+            .map_err(|e| e.to_string())?;
+
+        let mut rows = root_dir_stmt
+            .query(rusqlite::params![analysis_root_dir])
+            .map_err(|e| e.to_string())?;
+
+        if let Some(row) = rows.next().map_err(|e| e.to_string())? {
+            let id: i64 = row.get(0).map_err(|e| e.to_string())?;
+            Ok(id)
+        } else {
+            self.connection
+                .execute(
+                    "INSERT INTO analysis_root_dirs (dir_path) VALUES (?1)",
+                    [&analysis_root_dir],
+                )
+                .map_err(|e| format!("Failed to insert into analysis_root_dirs db: {}", e))?;
+
+            let id = self.connection.last_insert_rowid();
+            Ok(id)
+        }
+    }
+
+    /// Inserts metadata for a sample and returns the row id
+    pub fn insert_sample_metadata(
+        &self,
+        file_path: &str,
+        analysis_root_dir_id: i64,
+    ) -> Result<i64, String> {
+        self.connection
+            .execute(
+                "INSERT INTO samples (file_path, analysis_root_dir_id) VALUES (?1, ?2)",
+                [&file_path, &analysis_root_dir_id.to_string().as_str()],
+            )
+            .map_err(|e| format!("Error inserting into sqlite db: {}", e))?;
+
+        Ok(self.connection.last_insert_rowid())
+    }
+
+    pub fn list_file_paths(&self) -> Result<Vec<String>, String> {
+        let mut query = self
+            .connection
+            .prepare("SELECT id, file_path FROM samples LIMIT 500")
+            .map_err(|e| format!("Failed to prepare sqlite query: {}", e))?;
+        let mut rows = query.query([]).map_err(|e| e.to_string())?;
+        let mut paths = Vec::new();
+        while let Some(row) = rows.next().map_err(|e| e.to_string())? {
+            let id: i64 = row.get(0).unwrap();
+            let path: String = row.get(1).unwrap();
+            paths.push(format!("{}: {}", id, path));
+        }
+        Ok(paths)
+    }
+}

--- a/src/metadata_db.rs
+++ b/src/metadata_db.rs
@@ -116,15 +116,12 @@ impl MetadataDatabase {
     ) -> Result<Vec<AudioFile>, String> {
         let mut query = self
             .connection
-            .prepare(
-                format!(
-                    "SELECT id, file_path FROM samples WHERE id > {} ORDER BY file_path LIMIT {}",
-                    start_offset, limit
-                )
-                .as_str(),
-            )
+            .prepare("SELECT id, file_path FROM samples WHERE id > ?1 ORDER BY file_path LIMIT ?2")
             .map_err(|e| format!("Failed to prepare sqlite query: {}", e))?;
-        let mut rows = query.query([]).map_err(|e| e.to_string())?;
+
+        let mut rows = query
+            .query(rusqlite::params![start_offset, limit])
+            .map_err(|e| e.to_string())?;
         let mut files: Vec<AudioFile> = Vec::new();
         while let Some(row) = rows.next().map_err(|e| e.to_string())? {
             let id: i64 = row.get(0).unwrap();

--- a/src/metadata_db.rs
+++ b/src/metadata_db.rs
@@ -118,7 +118,7 @@ impl MetadataDatabase {
             .connection
             .prepare(
                 format!(
-                    "SELECT id, file_path FROM samples WHERE id > {} ORDER BY id LIMIT {}",
+                    "SELECT id, file_path FROM samples WHERE id > {} ORDER BY file_path LIMIT {}",
                     start_offset, limit
                 )
                 .as_str(),

--- a/src/metadata_db.rs
+++ b/src/metadata_db.rs
@@ -6,7 +6,7 @@ pub struct MetadataDatabase {
     connection: Connection,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct AudioFile {
     id: i64,
     path: String,
@@ -172,6 +172,13 @@ impl MetadataDatabase {
             let path: String = row.get(1).unwrap();
             files.push(AudioFile { id, path });
         }
-        Ok(files)
+        // The result of the sql query isn't guaranteed to match the order of ids, which are
+        // ranked by most to least similar. So, manually get the AudioFiles into order before
+        // returning.
+        let ordered_files: Vec<AudioFile> = ids
+            .iter()
+            .filter_map(|id| Some(files.iter().find(|f| f.id() == *id as i64)?.clone()))
+            .collect();
+        Ok(ordered_files)
     }
 }

--- a/src/metadata_db.rs
+++ b/src/metadata_db.rs
@@ -152,4 +152,26 @@ impl MetadataDatabase {
         }
         Ok(files)
     }
+
+    pub fn get_audio_files_for_ids(&self, ids: &[u32]) -> Result<Vec<AudioFile>, String> {
+        let id_list: String = ids
+            .iter()
+            .map(|id| id.to_string())
+            .collect::<Vec<_>>()
+            .join(",");
+        let query = format!(
+            "SELECT id, file_path FROM samples WHERE id IN ({})",
+            id_list
+        );
+
+        let mut stmt = self.connection.prepare(&query).map_err(|e| e.to_string())?;
+        let mut rows = stmt.query([]).map_err(|e| e.to_string())?;
+        let mut files = Vec::new();
+        while let Some(row) = rows.next().map_err(|e| e.to_string())? {
+            let id: i64 = row.get(0).unwrap();
+            let path: String = row.get(1).unwrap();
+            files.push(AudioFile { id, path });
+        }
+        Ok(files)
+    }
 }


### PR DESCRIPTION
Previously, the metadata (i.e. file ID and path) was saved to a JSON file and deserialized into a hash map in memory which wouldn't scale well for large data sets or schema changes.